### PR TITLE
fix: add new css asset

### DIFF
--- a/matterport-dl.py
+++ b/matterport-dl.py
@@ -165,7 +165,7 @@ def downloadAssets(base):
     "vert_arrows"]
 
     assets = ["css/showcase.css", "css/unsupported_browser.css", "cursors/grab.png", "cursors/grabbing.png", "cursors/zoom-in.png",
-    "cursors/zoom-out.png", "locale/strings.json",]
+    "cursors/zoom-out.png", "locale/strings.json", "css/ws-blur.css"]
 
     for image in image_files:
         if not image.endswith(".jpg") and not image.endswith(".svg"):


### PR DESCRIPTION
Hello,

This is a fix to support the new update of matterport, a new css file have been added : "css/ws-blur.css" which require to be downloaded in order to make the local version work.

Cheers,
David