### PR TITLE
Download logging standardized, brute JS file option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A tool to download/archive [Matterport](https://matterport.com) virtual tours.  
 # Advanced Options
 -   Add `--proxy 127.0.0.1:1234` to a download run to use a proxy for requests
 -   Add `--advanced-download` to a download run to try and download the needed textures and files for supporting dollhouse/floorplan views.  NOTE: Must use built in webserver to host content for this to work.
-
+-	Add `--brute-js` to try and download all js files 0->999 rather than just the ones detected.  Useful if you see 404 errors for js/XXX.js (where  XXX is a number)
 
 # Additional Notes
 * It is possible to host these Matterport archives using standard web servers however: 1) Certain features beyond the tour itself may not work.  2)  #1 may be fixable by specific rewrite rules for apache/nginx.  These are not currently provided but if you look at `OurSimpleHTTPRequestHandler` class near the bottom of the source file you can likely figure out what redirects we do.


### PR DESCRIPTION
Added more standardized logging to file fetches
Try to only use discovered JS files rather than hardcoded list
Doesn't fix current error but
closes #53 
closes #49 
closes #48 
closes #47 
closes #45 

if we run into errors we could simply hardcode static js files that cannot automatically be discovered.   Should cutdown on updates.

For users if this breaks something the new --brute-js should dl all numerical js files.