### PR TITLE
71 - Add helpful logging for certification failure

### DIFF
--- a/matterport-dl.py
+++ b/matterport-dl.py
@@ -508,7 +508,13 @@ if __name__ == "__main__":
         pageId = getPageId(sys.argv[1])
     openDirReadGraphReqs("graph_posts",pageId)
     if len(sys.argv) == 2:
-        initiateDownload(pageId)
+        try:
+            initiateDownload(pageId)
+        except Exception as error:
+            if "certificate verify failed" in str(error):
+                print (f"Error: {str(error)}. Have you tried running the Install Certificates.command file in the python folder?")
+            else:
+                print (f"Error: {str(error)}")
     elif len(sys.argv) == 4:
         os.chdir(getPageId(pageId))
         try:


### PR DESCRIPTION
# Background
When attempting to download a matterport the following error occured:
```
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)
```

# Solution
This issue was resolved by taking the following steps:
- Navigatie to the directory Python is installed
- Run the `Install Certificates.command` script
- Try downloading again

# Proposed Changes
- I've added in a try catch around the `initiateDownload` function
- The catch checks if the error message contains `certificate verify failed`, if it does, it will print a helpful hint after logging the error, which is: `Have you tried running the Install Certificates.command file in the python folder?`

# Issues affected
Closes #71 