### PR TITLE
Fixing f-strings and dicts key access error

### DIFF
--- a/matterport-dl.py
+++ b/matterport-dl.py
@@ -202,7 +202,7 @@ async def downloadFileWithJSONPost(type, shouldExist, url, file, post_json_str, 
 async def GetTextOnlyRequest(type, shouldExist, url, post_data=None) -> str:
     global PROGRESS
     useTmpFileName = ""
-    async with aiofiles.tempfile.NamedTemporaryFile(delete_on_close=False) as tmpFile:  # type: ignore
+    async with aiofiles.tempfile.NamedTemporaryFile() as tmpFile:  # type: ignore
         useTmpFileName = cast(str, tmpFile.name)
 
     result = await downloadFileAndGetText(type, shouldExist, url, useTmpFileName, post_data)
@@ -545,7 +545,7 @@ async def downloadPlugins(pageid):
     with open("api/v1/plugins", "r", encoding="UTF-8") as f:
         pluginJson = json.loads(f.read())
     for plugin in pluginJson:
-        plugPath = f"showcase-sdk/plugins/published/{plugin["name"]}/{plugin["currentVersion"]}/plugin.json"
+        plugPath = f"showcase-sdk/plugins/published/{plugin['name']}/{plugin['currentVersion']}/plugin.json"
         await downloadFile("PLUGIN", True, f"https://static.{BASE_MATTERPORT_DOMAIN}/{plugPath}", plugPath)
 
 
@@ -808,7 +808,7 @@ async def AdvancedAssetDownload(base_page_text: str):
             base_node["locations"] = base_cache_node["locations"]
 
         toDownload: list[AsyncDownloadItem] = []
-        consoleDebugLog(f"AdvancedDownload photos: {len(base_node_snapshots["assets"]["photos"])} meshes: {len(base_node["assets"]["meshes"])}, locations: {len(base_node["locations"])}, tileset indexes: {len(base_node["assets"]["tilesets"])}, textures: {len(base_node["assets"]["textures"])}, ")
+        consoleDebugLog(f"AdvancedDownload photos: {len(base_node_snapshots['assets']['photos'])} meshes: {len(base_node['assets']['meshes'])}, locations: {len(base_node['locations'])}, tileset indexes: {len(base_node['assets']['tilesets'])}, textures: {len(base_node['assets']['textures'])}, ")
 
         for mesh in base_node["assets"]["meshes"]:
             toDownload.append(AsyncDownloadItem("ADV_MODEL_MESH", "50k" not in mesh["url"], mesh["url"], urlparse(mesh["url"]).path[1:]))  # not expecting the non 50k one to work but mgiht as well try


### PR DESCRIPTION
Tried using the following recently on Python 3.13, and got some f-string errors due to the use of double quotes inside double quoted f-string.
Command: `python3 matterport-dl.py "https://my.matterport.com/show/?m=________&brand=0"`
Error:
```
File "/Users/_______/Downloads/matterport-dl/matterport-dl.py", line 548
    plugPath = f"showcase-sdk/plugins/published/{plugin["name"]}/{plugin["currentVersion"]}/plugin.json"
SyntaxError: f-string: unmatched '['
```
Fixed those by converting to single quote for dict keys, then received an error related to an unexpected parameter in NamedTemporaryFile() 

Error:
```
  File "/Users/________/Downloads/matterport-dl/matterport-dl.py", line 205, in GetTextOnlyRequest
    async with aiofiles.tempfile.NamedTemporaryFile(delete_on_close=False) as tmpFile:  # type: ignore
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: NamedTemporaryFile() got an unexpected keyword argument 'delete_on_close'
```

Fixed that by removing the parameter default value. 

The original download command then proceeded as normal and works again.