### PR TITLE
Fix reacts determination to set the source attribute in certain contains again after load breaking proxy

### DIFF
--- a/JSNetProxy.js
+++ b/JSNetProxy.js
@@ -90,3 +90,10 @@ Element.prototype.appendChild = function() {
 };
 
 console.log("PROXY IN PLACE");
+
+/*
+For react you may run into an issue:
+reactCont=reactCont.replace("(t.src=s.src)","(t.src=\"\"+(t.src??s.src))") # hacky but in certain conditions react will try to reset the source on something after it loads to re-trigger the load event but this breaks jsnetproxy.  This allows the same triggering but uses the existing source if it exists.  https://github.com/facebook/react/blob/37906d4dfbe80d71f312f7347bb9ddb930484d28/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js#L744
+
+we could check it after load but thats a bit of a pita can't seem to override the src attribute to make it read only or anything.  we could copy it but if it needs the handle to it that would break it.
+*/


### PR DESCRIPTION
Really close #114?

React has some slightly annoying code that can reset an images src after it loads which breaks our proxy.  This uses the existing source (if present) to trigger the same event but not change the source.

https://github.com/facebook/react/blob/37906d4dfbe80d71f312f7347bb9ddb930484d28/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js#L744