### PR TITLE
Fix regex to detect deferred JS files and prevent loading errors

### DIFF
--- a/matterport-dl.py
+++ b/matterport-dl.py
@@ -480,7 +480,7 @@ async def downloadAssets(base, base_page_text):
     # following seem no more: "css/split.css", "headset-cardboard", "headset-quest", "NoteIcon",  "puck_256_red", "tagbg", "tagmask", "roboto-700-42_0", "pinIconDefault",
 
     # downloadFile("my.matterport.com/favicon.ico", "favicon.ico")
-    base_page_js_loads = re.findall(r"script src=[\"']([^\"']+[.]js)[\"']", base_page_text, flags=re.IGNORECASE)
+    base_page_js_loads = re.findall(r"script\s+(?:defer\s+)?src=[\"']([^\"']+[.]js)[\"']", base_page_text, flags=re.IGNORECASE)
 
     # now they use module imports as well like: import(importBase + 'js/runtime~showcase.69d7273003fd73b7a8f3.js'),
 


### PR DESCRIPTION
Hello, 

I found this really helpful repository but I got an error when running it.
JS files included in the index.html are now loaded in 'defer' mode (which I guess is new) :

```
<script defer src="js/packages-cwf-core.8d0a7ec2b6efc21420ff.js">
```
It prevents the regex from detecting those scripts.
I updated the regex so that it can detect all js files whether they are loaded in defer mode or not. It seems to work well now.

Thanks for this repo !
