### PR TITLE
Check python version before creating a venv

### DIFF
--- a/run.py
+++ b/run.py
@@ -334,6 +334,7 @@ def main():
         return
 
     # We're now running in the virtual environment
+
     # Check for required files
     check_required_files(script_dir)
 


### PR DESCRIPTION
This is a small fix to check the python version before creating the virtual environment. venv will create an environment using the Python version that is currently installed, if your on an older version than what is supported this virtual environment will be this older version.

After upgrading Python you will still get a `Error: Python 3.12 or higher is required. You are using ... ` error even after upgrading. The workaround is to delete the venv folder, but this fix also addresses this.