### PR TITLE
Fixes #200 - Fix escaped validUntil fields not being updated to 2099 inside HTML

### DIFF
--- a/matterport-dl.py
+++ b/matterport-dl.py
@@ -328,7 +328,9 @@ async def downloadFile(type, shouldExist, url, file, post_data=None, always_down
 
 
 def validUntilFix(text):
-    return re.sub(r"validUntil\"\s*:\s*\"20[\d]{2}-[\d]{2}-[\d]{2}T", 'validUntil":"2099-01-01T', text)
+    text = re.sub(r"validUntil\"\s*:\s*\"20[\d]{2}-[\d]{2}-[\d]{2}T", 'validUntil":"2099-01-01T', text) # Unescaped JSON
+    text = re.sub(r'\\\"validUntil\\\":\\\"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z', '\\"validUntil\\":\\"2099-01-01T00:00:00Z', text) # Escaped JSON
+    return text
 
 
 async def downloadGraphModels(pageid):


### PR DESCRIPTION
## Summary

Fixes #200 

- What problem does this PR solve or feature does it add?
  Escaped validUntil fields inside index.modified.html were not being updated to 2099. Only unescaped JSON was updated, causing downloaded tours to expire after 24 hours and fail to load.

- What changed to solve it?
  Added a minimal additional regex to validUntilFix to correctly match and update escaped JSON timestamps (e.g. \"validUntil\":\"2026-…\"). This ensures both escaped and unescaped timestamps are updated consistently.

- Other Notes / information
  A similar issue previously affected .json files (issue #123) and was fixed in commit 1930995. Escaped JSON inside HTML appears to have been added later and was not covered by the original fix. This PR keeps the change minimal and scoped.

## Validation

- How did you verify the change works?
  Downloaded a tour, inspected all files containing validUntil, and confirmed both escaped and unescaped timestamps are updated to 2099-01-01T00:00:00Z. Verified that the tour loads correctly after 24 hours.

- What edge cases did you test (if any)?
  - Files with multiple validUntil occurrences
  - Files containing only escaped JSON
  - Files containing only unescaped JSON
  - Verified no unrelated fields were modified

## AI-Assisted Development Disclosure

1. Roughly what percentage of this PR was generated by AI?
   - [x] <5%
   - [ ] 5-33%
   - [ ] 33-66%
   - [ ] 66-90%
   - [ ] 90-100%

2. Are there any sections you do not fully understand, or where you are unsure the AI made the right implementation choice?
   - [x] No
   - [ ] Yes (please explain below)

3. How confident are you that this change addresses the root cause (not just symptoms)?
   - [ ] Low
   - [ ] Medium
   - [x] High
   - [ ] Very High

## AI Code Review Checklist

- [x] No unnecessary duplication (DRY was followed; repeated logic was refactored appropriately).
- [x] No avoidable hardcoded values/strings where parsing, configuration, or detection is more appropriate.
- [x] Changes are scoped to the issue and avoid unrelated modifications.
- [x] The final diff is concise and review-friendly.