### PR TITLE
Fix chunk discovery for current Matterport webpack builds, plus two alias/rename bugs

### DIFF
--- a/_matterport_interactive.py
+++ b/_matterport_interactive.py
@@ -96,10 +96,9 @@ def create_alias_smylink(model_id, alias):
     """Create a symlink in the downloads folder pointing to the model_id"""
     downloads_path = get_downloads_path()
     alias_path = os.path.join(downloads_path, alias)
-    model_path = os.path.join(downloads_path, model_id)
     if not os.path.exists(alias_path):
         try:
-            os.symlink(model_path, alias_path)
+            os.symlink(model_id, alias_path)  # relative target: alias_path and model_id are siblings inside downloads_path
             print_colored(f"Created symlink {alias} pointing to {model_id}", bcolors.OKGREEN)
         except OSError as e:
             print_colored(f"Error creating symlink alias {alias}: {e}", bcolors.WARNING)

--- a/matterport-dl.py
+++ b/matterport-dl.py
@@ -614,7 +614,14 @@ async def downloadAssets(base, base_page_text):
     # the newly downloaded chunks too since they can reference further chunks of their own
     # (e.g. init.js has its own logo/locale context map). Bounded to a few rounds so this
     # can't loop forever if chunks end up referencing each other.
+    # scannedFiles avoids re-scanning a bundle we've already read on a later round - only
+    # newly-downloaded chunks need to be scanned again each time round the loop.
     scannedFiles: set[str] = set()
+    # 5 rounds is a heuristic, not a derived bound: in testing, newly-discovered chunks (e.g.
+    # init.js) only ever added one further round's worth of their own chunk references before
+    # settling, so this comfortably covers that with room to spare. The `if not chunkDownload:
+    # break` below is what actually ends the loop in the normal case; this cap only exists so a
+    # future build that references chunks in a cycle can't turn this into an infinite loop.
     for _ in range(5):
         discoveredChunkIds: set[str] = set()
         for asset in assets:
@@ -633,12 +640,17 @@ async def downloadAssets(base, base_page_text):
                 typeDict[jsFile] = "SHOWCASE_DISCOVERED_CHUNK_JS"
                 assets.append(jsFile)
                 chunkDownload.append(AsyncDownloadItem("SHOWCASE_DISCOVERED_CHUNK_JS", False, f"{base}{jsFile}", jsFile))
+            # Most chunk ids don't have a css counterpart, and we have no cheap way to know
+            # which ones do ahead of time (that mapping isn't exposed anywhere we can parse
+            # like the named js/css maps above are). shouldExist=False here means a 404 for
+            # the ones that don't is expected and silent, matching the existing convention
+            # used elsewhere in this file for speculative/best-effort downloads.
             cssFile = f"css/{cssNamedDict.get(chunkId, chunkId)}.css"
             if cssFile not in typeDict:
                 typeDict[cssFile] = "SHOWCASE_DISCOVERED_CHUNK_CSS"
                 assets.append(cssFile)
                 chunkDownload.append(AsyncDownloadItem("SHOWCASE_DISCOVERED_CHUNK_CSS", False, f"{base}{cssFile}", cssFile))
-        if not chunkDownload:
+        if not chunkDownload:  # nothing new discovered this round - normal loop exit
             break
         await AsyncArrayDownload(chunkDownload)
 

--- a/matterport-dl.py
+++ b/matterport-dl.py
@@ -1507,7 +1507,7 @@ def RegisterWindowsBrowsers():
 
 def startServer(baseDir, pageId, browserLaunch, bindAddress, bindPort):
     global SERVED_BASE_URL
-    twinDir = getPageId(pageId)
+    twinDir = pageId  # pageId is already resolved/validated by the caller (raw id, or an existing download folder/rename alias)
     if not os.path.exists(twinDir):
         fullPath = os.path.abspath(twinDir)
         relativeToScriptDir = os.path.join(BASE_MATTERPORTDL_DIR, baseDir, twinDir)
@@ -1824,7 +1824,10 @@ def main():
         # Check if pageIdOrIp is an IP address
         ip_pattern = re.compile(r"^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$")
         if not ip_pattern.match(pageIdOrIp):
-            pageId = getPageId(pageIdOrIp)
+            if os.path.exists(os.path.join(baseDir, pageIdOrIp)):
+                pageId = pageIdOrIp  # an existing download folder or rename alias - skip raw id/url validation
+            else:
+                pageId = getPageId(pageIdOrIp)
             argPos += 1
             if len(sys.argv) == argPos:  # if no more args its a download run
                 isDownloadRun = True

--- a/matterport-dl.py
+++ b/matterport-dl.py
@@ -456,23 +456,36 @@ def _logUrlDownload(logLevel, logPrefix, type, localTarget, url, additionalParam
     logging.log(logLevel, f"{logPrefix} REQ for {type} {requestID}: should exist: {shouldExist} {optionalResult} File: {localTarget} at url: {url} {key_type} {additionalParams}")
 
 
-def extractJSDict(forWhat: str, str: str):
-    ret: dict[str, str] = {}
-    # Expects a string where the first { starts the dict and last } ends it.
-    startPos = str.find("{")
-    if startPos == -1:
-        raise Exception(f"Unable to extract JS dictionary for: {forWhat} from the JS string: {str} can't find first {{")
-    endPos = str.rfind("}")
-    if endPos == -1:
-        raise Exception(f"Unable to extract JS dictionary for: {forWhat} from the JS string: {str} can't find last }}")
-    str = str[startPos + 1 : endPos]
-    pairs = str.split(",")
-    for kvp in pairs:
-        arr = kvp.replace('"', "").split(":")
-        key = arr[0]
-        key = int(float(key))  # keys can be in scientific notation
-        ret[f"{key}"] = arr[1]
-    return ret
+def extractBraceBlock(text, start_marker):
+    # Finds start_marker in text, then returns the full {...} object literal that follows it
+    # (brace-depth matched, so nested braces in values don't cut it short). Returns None if
+    # the marker or a balanced brace block can't be found.
+    idx = text.find(start_marker)
+    if idx == -1:
+        return None
+    brace_start = text.find("{", idx)
+    if brace_start == -1:
+        return None
+    depth = 0
+    for i in range(brace_start, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[brace_start : i + 1]
+    return None
+
+
+def extractJSDict(forWhat, js_string):
+    """
+    Parses a JS object literal of the form {123:"name",456:"other",...} (bare numeric
+    keys, quoted string values) as used by Matterport's webpack chunk filename maps,
+    e.g. l.u=e=>"js/"+({123:"name"}[e]||e)+".js"
+    """
+    if not js_string:
+        return {}
+    return {m.group(1): m.group(2) for m in re.finditer(r'(\d+)\s*:\s*"([^"]*)"', js_string)}
 
 
 async def downloadAssets(base, base_page_text):
@@ -539,62 +552,29 @@ async def downloadAssets(base, base_page_text):
     await downloadFile("STATIC_ASSET", True, "https://matterport.com/nextjs-assets/images/favicon.ico", "favicon.ico")  # mainly to avoid the 404, always matterport.com
     showcase_cont = await downloadFileAndGetText(typeDict[showcase_runtime_filename], True, base + showcase_runtime_filename, showcase_runtime_filename, always_download=CLA.getCommandLineArg(CommandLineArg.REFRESH_KEY_FILES))
 
-    # lets try to extract the js files it might be loading and make sure we know them, the code has things like .e(858)  ot load which are the numbers we care about
-    # js_extracted = re.findall(r"\.e\(([0-9]{2,3})\)", showcase_cont)
-    # here is how the JS is prettied up (aka with spaces).  First are JS files with specific names, second are the js files to key, and finally are the css files.   The js files with specific names you still need the key for just instead of [number].[key].js it is [name].[key].js
-    # , d.u = e => "js/" + ({
-    #     239: "three-examples",
-    #     777: "split",
-    #     1662: "sdk-bundle",
-    #     9114: "core",
-    #     9553: "control-kit"
-    # } [e] || e) + "." + {
-    #     172: "6c50ed8e5ff7620de75b",
-    #     9553: "8aa28bbfc8f4948fd4d1",
-    #     9589: "dc4901b493f7634edbcf",
-    #     9860: "976dc6caac98abda24c9"
-    # } [e] + ".js", d.miniCssF = e => "css/" + ({
-    #     7475: "late",
-    #     9114: "core"
-    # } [e] || e) + ".css"
+    # Matterport's webpack chunk loader no longer suffixes chunk filenames with a content
+    # hash (older builds served js/<name>.<hash>.js; current builds just serve js/<name>.js,
+    # or js/<id>.js for chunks with no friendly name). The runtime file exposes a name map
+    # for both js and css chunks, e.g.:
+    #   l.u = e => "js/" + ({239: "three-examples", 9553: "control-kit", ...}[e] || e) + ".js"
+    #   l.miniCssF = e => "css/" + ({7475: "late", 9114: "core", ...}[e] || e) + ".css"
+    # Only chunks that have a friendly name appear in these maps; the many numeric-only
+    # chunks referenced elsewhere (as i.e(1470) calls) are discovered later below, once we
+    # have the actual bundle files on disk to scan.
+    jsBlock = extractBraceBlock(showcase_cont, '"js/"+')
+    cssBlock = extractBraceBlock(showcase_cont, '"css/"+')
+    if jsBlock is None or cssBlock is None:
+        raise Exception("Unable to extract js/css chunk filename maps from showcase runtime js file")
+    jsNamedDict = extractJSDict("showcase-runtime.js: named js chunks", jsBlock)
+    cssNamedDict = extractJSDict("showcase-runtime.js: named css chunks", cssBlock)
 
-    match = re.search(
-        r"""
-                "js/"\+ # find js/+  (literal plus)
-                (?P<namedJSFiles>[^\[]+) #capture everything until the first [ character store in group namedJSFiles
-                (?P<JSFileToKey>.+?) #least greedy capture, so capture the minimum amount to make this regex still true
-                css #stopping when we see the css
-                (?P<namedCSSFiles>[^\[]+) #similar to before capture to first [
-                .+? #skip the minimum amount to get to next part
-                miniCss=.+? #find miniCss= then skip minimum to first &&
-                &&
-                (?P<CSSFileToKey>.+?) #capture minimum until we get to next &&
-                &&
-              """,
-        showcase_cont,
-        re.X,
-    )
-    if match is None:
-        raise Exception("Unable to extract js files and css files from showcase runtime js file")
-    groupDict = match.groupdict()
-    jsNamedDict = extractJSDict("showcase-runtime.js: namedJSFiles", groupDict["namedJSFiles"])
-    jsKeyDict = extractJSDict("showcase-runtime.js: JSFileToKey", groupDict["JSFileToKey"])
-    cssNamedDict = extractJSDict("showcase-runtime.js: namedCSSFiles", groupDict["namedCSSFiles"])
-    cssKeyDict = extractJSDict("showcase-runtime.js: CSSFileToKey", groupDict["CSSFileToKey"])
-
-    for number, key in jsKeyDict.items():
-        name = number
-        if name in jsNamedDict:
-            name = jsNamedDict[name]
-        file = f"js/{name}.{key}.js"
+    for number, name in jsNamedDict.items():
+        file = f"js/{name}.js"
         typeDict[file] = "SHOWCASE_DISCOVERED_JS"
         assets.append(file)
 
-    for number, key in cssKeyDict.items():
-        name = number
-        if name in cssNamedDict:
-            name = cssNamedDict[name]
-        file = f"css/{name}.css"  # key is not used for css its just 1 always
+    for number, name in cssNamedDict.items():
+        file = f"css/{name}.css"
         typeDict[file] = "SHOWCASE_DISCOVERED_CSS"
         assets.append(file)
 
@@ -623,6 +603,45 @@ async def downloadAssets(base, base_page_text):
         shouldExist = True
         toDownload.append(AsyncDownloadItem(type, shouldExist, f"{base}{asset}", local_file))
     await AsyncArrayDownload(toDownload)
+
+    # The named js/css maps above only cover chunks with a friendly name. Most chunks are
+    # referenced only by numeric id, either directly via calls like i.e(1470), or indirectly
+    # through webpack "require.context" maps used for lazy-loaded per-locale resources, e.g.
+    # showcase.js contains {"./cwf_en-US.yaml":[42622,2622], ...} where the second number of
+    # each pair is the chunk id (these are not optional: showcase.js's init path loads the
+    # current locale's entry from a map like this, so a missing one blanks the whole viewer).
+    # Scan every JS bundle on disk for both patterns, download whatever's missing, then rescan
+    # the newly downloaded chunks too since they can reference further chunks of their own
+    # (e.g. init.js has its own logo/locale context map). Bounded to a few rounds so this
+    # can't loop forever if chunks end up referencing each other.
+    scannedFiles: set[str] = set()
+    for _ in range(5):
+        discoveredChunkIds: set[str] = set()
+        for asset in assets:
+            local_file = asset.split("?")[0]
+            if local_file.endswith(".js") and local_file not in scannedFiles and os.path.exists(local_file):
+                scannedFiles.add(local_file)
+                with open(local_file, "r", encoding="UTF-8", errors="ignore") as f:
+                    text = f.read()
+                discoveredChunkIds.update(re.findall(r"\.e\((\d+)\)", text))
+                discoveredChunkIds.update(m.group(1) for m in re.finditer(r'"\./[^"]+"\s*:\s*\[\s*\d+\s*,\s*(\d+)\s*\]', text))
+
+        chunkDownload: list[AsyncDownloadItem] = []
+        for chunkId in discoveredChunkIds:
+            jsFile = f"js/{jsNamedDict.get(chunkId, chunkId)}.js"
+            if jsFile not in typeDict:
+                typeDict[jsFile] = "SHOWCASE_DISCOVERED_CHUNK_JS"
+                assets.append(jsFile)
+                chunkDownload.append(AsyncDownloadItem("SHOWCASE_DISCOVERED_CHUNK_JS", False, f"{base}{jsFile}", jsFile))
+            cssFile = f"css/{cssNamedDict.get(chunkId, chunkId)}.css"
+            if cssFile not in typeDict:
+                typeDict[cssFile] = "SHOWCASE_DISCOVERED_CHUNK_CSS"
+                assets.append(cssFile)
+                chunkDownload.append(AsyncDownloadItem("SHOWCASE_DISCOVERED_CHUNK_CSS", False, f"{base}{cssFile}", cssFile))
+        if not chunkDownload:
+            break
+        await AsyncArrayDownload(chunkDownload)
+
     if react_vendor_filename and os.path.exists(react_vendor_filename):
         reactCont = ""
         with open(react_vendor_filename, "r", encoding="UTF-8") as f:


### PR DESCRIPTION
## Summary

**1. Chunk discovery for current webpack builds (main fix)**

Matterport's showcase bundle no longer suffixes chunk filenames with a content hash (`js/<name>.<hash>.js`) — it now serves `js/<name>.js`, or `js/<id>.js` for chunks with no friendly name. The existing two-stage name+hash regex/dict extraction in `downloadAssets()` no longer matches, so it was silently discovering **zero** js/css chunks — including the `init` chunk required just to boot the viewer, plus every chunk referenced only by numeric id. Downloaded twins loaded to a blank screen with `ChunkLoadError` in the console.

What changed:
- Replaced the broken name+hash extraction with `extractBraceBlock()` (brace-depth matched, so it can't be cut short by nested braces) plus a simplified `extractJSDict()` that parses the current `{123:"name",...}` shape directly.
- Added a second pass in `downloadAssets()` that scans every downloaded JS bundle for chunk ids referenced via `i.e(N)` calls **and** via webpack `require.context` maps used for lazy-loaded per-locale/logo resources (e.g. `{"./cwf_en-US.yaml":[42622,2622]}` — the second number is the chunk id). It downloads whatever's still missing, then rescans the newly-downloaded chunks too, since some of them (e.g. `init.js`) have their own locale/logo context maps of the same kind. Bounded to 5 rounds so it can't loop forever.

Other notes: a handful of numeric chunk ids (observed: 654, 6180, 7391, 8893) consistently 403 even when requested directly by number, across two different live builds tested weeks apart. These appear to be unused/feature-gated code paths rather than something this fix is missing — the viewer works fully without them — but that's an inference from testing, not confirmed against Matterport's source.

**2. Two alias/rename bugs (found while testing the above)**

- `create_alias_smylink()` in `_matterport_interactive.py` built the symlink target as `downloads/<model_id>`, but since the symlink itself lives inside `downloads/`, that relative path resolves from within `downloads/` too, producing a broken `downloads/downloads/<model_id>` target. Fixed to use a bare `model_id` (alias and model dir are siblings).
- Serving by alias was broken despite being documented usage (`[url_or_page_id_or_alias]`): `getPageId()` unconditionally requires alnum-only, 5-15 char ids, so any alias with underscores or an unusual length raised an exception before ever checking whether a matching folder existed. `startServer()` then called `getPageId()` a second time on an already-resolved `pageId`, so fixing only the first call site wasn't enough. Both now trust an existing folder/alias name instead of re-validating it as a raw model id/url.

## Validation

- Reproduced the chunk-discovery failure live: downloaded a real model, confirmed `js/init.js`, `css/init.css`, and 8+ other core files were never fetched, and confirmed the exact browser failure (`ChunkLoadError: Loading chunk 2622 failed`, blank viewer).
- Applied the fix and re-downloaded the same model fresh: `init.js`/`init.css` and the previously-failing locale chunk (`js/2622.js`) are now fetched; the viewer loads and is fully interactive (walking between panoramas, dollhouse 3D mesh view, floorplan) with a clean browser console.
- Re-ran a full download against an already-complete archive to confirm the fix doesn't regress the normal "mostly skip, fill gaps" incremental-download behavior.
- For the alias fixes: created a rename alias with underscores, confirmed the symlink resolves to the real capture directory (previously dangling), and confirmed `matterport-dl.py <alias> ip port` serves the twin correctly (previously threw "Likely invalid model id extracted" immediately).
- Did not test against a defurnished model or a model with disabled/limited plugins for the chunk-discovery fix — it touches shared asset-discovery logic so it should apply equally, but I haven't specifically verified that path.

## AI-Assisted Development Disclosure

1. **Roughly what percentage of this PR was generated by AI?** 90-100% — the implementation was written by an AI coding agent (Claude Code); I directed the investigation, reviewed the diff, and verified each fix live myself (browser testing for the chunk discovery and alias-serving fixes).
2. **Are there any sections you do not fully understand, or where you are unsure the AI made the right implementation choice?** Yes:
   - The 5-round bounded rescan loop (chunk discovery) is a heuristic cap, not a principled bound — I don't have strong intuition for whether 5 is the right number vs. 2 or 10.
   - The chunk-discovery fix speculatively probes for a same-numbered CSS file for every discovered chunk id, even though most chunks don't have one. It works (failures are harmless/expected `shouldExist=False` misses), but I'm not fully certain this is the cleanest way to handle it vs. only doing this for ids known to have CSS.
3. **How confident are you that this change addresses the root cause (not just symptoms)?** Very High for all three fixes — each was directly reproduced and tied to a specific, concrete failure (a console error and missing file for chunk discovery; an exception message and a broken symlink for the alias bugs), and each fix was verified to resolve that exact failure.