### PR TITLE
fix: never return an empty response for /api/mp/models/graph

### DIFF
--- a/matterport-dl.py
+++ b/matterport-dl.py
@@ -1383,7 +1383,10 @@ class OurSimpleHTTPRequestHandler(SimpleHTTPRequestHandler):
         file_path = f"api/mp/models/graph_{option_name}.json"
         if option_name is not None and re.fullmatch(r"\w+", option_name) and os.path.exists(file_path):
             with open(file_path, "r", encoding="UTF-8") as f:
-                self.wfile.write(f.read().encode("utf-8"))
+                text = f.read()
+            # archives made by old forks baked their local server origin (http://127.0.0.1:8080) into the saved graph responses, make those root-relative so they work on any host/port
+            text = re.sub(r"https?://(?:127\.0\.0\.1|localhost)(?::\d+)?/", "/", text)
+            self.wfile.write(text.encode("utf-8"))
             post_msg = f"graph of operationName: {option_name} we are handling internally"
         else:
             logLevel = logging.WARNING

--- a/matterport-dl.py
+++ b/matterport-dl.py
@@ -1375,23 +1375,22 @@ class OurSimpleHTTPRequestHandler(SimpleHTTPRequestHandler):
         return False
 
     def do_GraphRequest(self, option_name: str):
-        post_msg = None
         logLevel = logging.INFO
-        if option_name in GRAPH_DATA_REQ:
-            self.send_response(200)
-            self.end_headers()
-            file_path = f"api/mp/models/graph_{option_name}.json"
-            if os.path.exists(file_path):
-                with open(file_path, "r", encoding="UTF-8") as f:
-                    self.wfile.write(f.read().encode("utf-8"))
-                    post_msg = f"graph of operationName: {option_name} we are handling internally"
-            else:
-                logLevel = logging.WARNING
-                post_msg = f"graph for operationName: {option_name} we don't know how to handle, but likely could add support, returning empty instead. If you get an error this may be why (include this message in bug report)."
-                self.wfile.write(bytes('{"data": "empty"}', "utf-8"))
+        # always answer with a valid HTTP response, an unknown operationName must not close the connection empty
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        file_path = f"api/mp/models/graph_{option_name}.json"
+        if option_name is not None and re.fullmatch(r"\w+", option_name) and os.path.exists(file_path):
+            with open(file_path, "r", encoding="UTF-8") as f:
+                self.wfile.write(f.read().encode("utf-8"))
+            post_msg = f"graph of operationName: {option_name} we are handling internally"
+        else:
+            logLevel = logging.WARNING
+            post_msg = f"graph for operationName: {option_name} we don't know how to handle, but likely could add support, returning empty instead. If you get an error this may be why (include this message in bug report)."
+            self.wfile.write(bytes('{"data": "empty"}', "utf-8"))
 
-        if post_msg is not None:
-            consoleDebugLog(f"Handling a graph request on {self.path}: {post_msg}", loglevel=logLevel)
+        consoleDebugLog(f"Handling a graph request on {self.path}: {post_msg}", loglevel=logLevel)
 
     def do_POST(self):
         post_msg = None

--- a/matterport-dl.py
+++ b/matterport-dl.py
@@ -1309,8 +1309,10 @@ class OurSimpleHTTPRequestHandler(SimpleHTTPRequestHandler):
         global BASE_MATTERPORTDL_DIR
         redirect_msg = None
         orig_request = self.path
-        if not CLA.getCommandLineArg(CommandLineArg.TILDE):
-            self.path = self.path.replace("~", "_")
+        if not CLA.getCommandLineArg(CommandLineArg.TILDE) and "~" in self.path:
+            # archives made by old forks store assets under literal ~ dirs, keep the request as-is when that file exists
+            if not os.path.exists(f".{urllib.parse.unquote(self.getRawPath())}"):
+                self.path = self.path.replace("~", "_")
 
         orig_raw_path = raw_path = self.getRawPath()
         query = self.getQuery()
@@ -1384,8 +1386,11 @@ class OurSimpleHTTPRequestHandler(SimpleHTTPRequestHandler):
         if option_name is not None and re.fullmatch(r"\w+", option_name) and os.path.exists(file_path):
             with open(file_path, "r", encoding="UTF-8") as f:
                 text = f.read()
-            # archives made by old forks baked their local server origin (http://127.0.0.1:8080) into the saved graph responses, make those root-relative so they work on any host/port
-            text = re.sub(r"https?://(?:127\.0\.0\.1|localhost)(?::\d+)?/", "/", text)
+            # archives made by old forks baked their local server origin (http://127.0.0.1:8080) into the saved graph responses, point those at whatever host we are being reached on instead; must stay absolute as the showcase url machinery rejects relative urls here
+            request_host = self.headers.get("Host")
+            if request_host is not None:
+                scheme = self.headers.get("X-Forwarded-Proto", "http")
+                text = re.sub(r"https?://(?:127\.0\.0\.1|localhost)(?::\d+)?/", f"{scheme}://{request_host}/", text)
             self.wfile.write(text.encode("utf-8"))
             post_msg = f"graph of operationName: {option_name} we are handling internally"
         else:


### PR DESCRIPTION
## Summary

- **What problem does this PR solve or feature does it add?**

  The offline server failed to render models — especially models that were captured with older versions or third-party forks of matterport-dl. Symptoms, in the order they were hit:
  1. The browser aborted with `net::ERR_EMPTY_RESPONSE` on `POST /api/mp/models/graph` and the showcase never loaded (`MdsReadError` code `61000`, "Failed to fetch"). The showcase's very first GraphQL call (`modelExists`) uses an `operationName` that isn't in the current hardcoded `GRAPH_DATA_REQ` dict, and the handler returned without writing any HTTP response, so the connection closed empty.
  2. After that was fixed, the model mesh failed to load ("Oops, model not available" / `MeshCreationException`) because the saved `graph_*.json` files had a local server origin (`http://127.0.0.1:8080`) baked into their asset URLs at capture time, so the browser fetched the mesh/images from a dead origin.
  3. After the origin was rewritten, mesh loading still failed with "No suitable model file found" (no network request at all), and panorama tiles 404'd at `.../assets/~/tiles/...`.

- **What changed to solve it?**

  All changes are in `matterport-dl.py`, in the request handler used when serving a downloaded model:
  - **`do_GraphRequest`** now always sends a valid `200` + `Content-Type: application/json` response before writing any body, so an unknown `operationName` can never close the connection empty. It also serves any `graph_<operationName>.json` present on disk even if the operation isn't in the current `GRAPH_DATA_REQ` dict (older archives saved more operations than the current dict lists), and sanitizes `operationName` before using it in the file path.
  - When serving a graph response, baked-in `http://127.0.0.1:<port>/` (and `localhost`) origins are rewritten to point at the host the request actually arrived on (built from the `Host` header, honoring `X-Forwarded-Proto`). It must stay an **absolute** URL — the showcase's signed-URL machinery rejects relative URLs before it ever fetches, which was the cause of the "No suitable model file found" failure.
  - `do_GET` no longer blindly rewrites `~` → `_` in request paths. Older archives store assets under literal `~` directories, so the request path is kept as-is when that file exists on disk and only falls back to the `_` replacement otherwise.

- **Other Notes / information**

  - This effectively re-applies a prior fix (commit `dede724`) for the empty-graph-response case that had been silently reverted by a later commit (`a680ede`), and extends it.
  - The archive used to reproduce this was originally captured with the `mu-ramadan/matterport-dl` fork; the baked `127.0.0.1:8080` origin and the literal `~` asset directories are conventions of that older download path. The fixes are on the **serving** side, so existing archives on disk are not modified and don't need to be re-downloaded.

## Validation

- **How did you verify the change works?**

  Ran the server against a real downloaded model and exercised it end-to-end, both with `curl` and in the browser:
  - Every graph operation present on disk (`GetModelViewPrefetch`, `GetCurrentUserModelAccess`, `GetModelPolicies`, `GetHighlightReel`, `GetMattertags`, `GetMeasurements`, `GetLabels`, `GetSnapshots`, `GetModelDetails`) now returns `200` with its JSON; previously the ones missing from `GRAPH_DATA_REQ` returned "Empty reply from server".
  - The `GetModelDetails` response served by the running server contains zero `127.0.0.1:8080` references and emits the mesh URL as an absolute URL on the request's own host; `GET`ing that URL returns the full `_50k.dam` (200, ~1.4 MB).
  - The panorama tile under a literal `~` directory (`.../assets/~/tiles/.../512_face0_0_0.jpg`) returns `200`, and the mesh `.dam` still returns `200`.
  - Confirmed in the browser that the showcase progresses past `modelExists` and loads the model view.

- **What edge cases did you test (if any)?**
  - Unknown / unsupported `operationName` → returns the `{"data": "empty"}` stub with a `200` instead of hanging.
  - Path-traversal-shaped `operationName` (e.g. `../../../etc/passwd`) → rejected by the `\w+` sanitization, returns the empty stub.
  - A `~`-containing request path that does **not** exist on disk → still falls back to the `_` replacement and 404s cleanly (no crash), preserving existing behavior for archives captured without literal-tilde dirs.
  - Non-graph `GET`s (e.g. `index.html`) unaffected.

## AI-Assisted Development Disclosure

Please be transparent if AI tools were used.

1. Roughly what percentage of this PR was generated by AI?
   - [X] 90-100%

2. Are there any sections you do not fully understand, or where you are unsure the AI made the right implementation choice?
   - [ ] No
   - [X] Yes (please explain below)

   - The `Host`-header-based origin rewrites `127.0.0.1`/`localhost` origins.
   - The rewrite happens at serve time on every graph response rather than being normalized once at download time. That keeps existing archives working without re-downloading, but a reviewer may prefer normalizing on capture instead (or in addition).

3. How confident are you that this change addresses the root cause (not just symptoms)?
   - [ ] Low
   - [ ] Medium
   - [ ] High
   - [X] Very High

   Each of the three failures was traced to its origin (empty HTTP response from an early return; a capture-time baked origin; a client-side relative-URL rejection plus a `~`→`_` path rewrite) and fixed at that point, then verified by observing the previously-failing request succeed.

## AI Code Review Checklist

For AI-generated or AI-assisted code, please confirm you reviewed the following things that AI can have a tendency to do and tried to minimize them:

- [X] No unnecessary duplication ([DRY](https://www.geeksforgeeks.org/software-engineering/dont-repeat-yourselfdry-in-software-development/) was followed; repeated logic was refactored appropriately). The graph handler was collapsed to a single response path rather than duplicating the send/write logic across branches.
- [X] No avoidable hardcoded values/strings where parsing, configuration, or detection is more appropriate. The serving host is detected from the request's `Host` header rather than hardcoded; the tilde behavior is driven by on-disk existence rather than an assumption.
- [X] Changes are scoped to the issue and avoid unrelated modifications. All changes are confined to the request handler in `matterport-dl.py`; no unrelated files or behaviors were touched.
- [X] The final diff is concise and review-friendly.